### PR TITLE
JPA MySQL 기본 InnoDB로 설정

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,4 +11,4 @@ spring:
     properties:
       hibernate:
         format_sql: true
-    database-platform: org.hibernate.dialect.MySQL5Dialect
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect


### PR DESCRIPTION
## 요약
MyISAM을 쓰면 `@Transactional`을 통해 롤백을 할 수 없습니다. (테스트 코드 작성 시 불편..)

#### Why?
MyISAM은 Transaction을 지원하는 DB엔진이 아니기 때문에 commit / rollback은 Ignore 됩니다.

## 변경사항
Dialect를 변경해서 기본 DB엔진을 InnoDB로 사용하도록 합니다